### PR TITLE
Disallow invalid timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Akka Streams Kinesis
+
+[![Build Status](https://travis-ci.org/timeoutdigital/akka-streams-kinesis.svg?branch=master)](https://travis-ci.org/timeoutdigital/akka-streams-kinesis)
+
+This library allows you to read from and write to Kinesis with Akka Streams. It is currently under active development.
+
+## Reading from Kinesis
+
+You can read from Kinesis with `KinesisSource`. It currently polls kinesis every 100ms with the Java async client.
+
+```scala
+import com.timeout.KinesisSource
+import java.time.ZonedDateTime
+
+val since = ZonedDateTime.now() // from when to start reading the stream
+val stage = KinesisSource("my-stream-name", since = since)
+```
+
+⚠️ Currently not supported:
+
+ - Shard iterator types other than `AT_TIMESTAMP`
+ - More than 5 minutes of backpressure 
+ - [Resharding of the stream](http://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-resharding.html)
+
+ 
+## Writing to Kinesis
+
+You can write to Kinesis with `KinesisGraphStage`. It maintains an internal buffer of records which it flushes periodically to Kinesis. and emits a stream of  `Either[PutRecordsResultEntry, A]` where the left is any failed results from kinesis and the right is the records pushed successfully.
+
+KinesisGraphStage expects you to implement a typeclass `ToPutRecordsRequest[A]` which tells it how to convert the contents of your stream into a `PutRecordsRequest`.
+
+```scala
+import java.nio.ByteBuffer
+
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
+import com.timeout.{KinesisGraphStage, ToPutRecordsRequest}
+import com.amazonaws.services.kinesis.model.PutRecordsRequestEntry
+
+implicit val instance = ToPutRecordsRequest.instance[String] { str =>
+  new PutRecordsRequestEntry().withData(ByteBuffer.wrap(str.getBytes))
+}
+
+val kinesis = new AmazonKinesisAsyncClient()
+val stage = KinesisGraphStage.withClient[String](kinesis, "my-stream")
+// stage: Flow[String, Either[PutRecordsResultEntry,String], NotUsed]
+```

--- a/src/main/scala/com/timeout/KinesisSource.scala
+++ b/src/main/scala/com/timeout/KinesisSource.scala
@@ -9,9 +9,9 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import akka.stream.stage.{GraphStage, OutHandler, StageLogging, TimerGraphStageLogic}
 import akka.stream.{Attributes, Outlet, SourceShape}
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.kinesis.model._
+import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClientBuilder}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -21,12 +21,13 @@ import scala.util.Try
 
 object KinesisSource {
 
-  private [timeout] val region: Region =
+  private [timeout] val region: Regions =
     Option(Regions.getCurrentRegion)
-      .getOrElse(Region.getRegion(Regions.EU_WEST_1))
+      .map(r => Regions.fromName(r.getName))
+      .getOrElse(Regions.EU_WEST_1)
 
-  private[timeout] lazy val kinesis: AmazonKinesisAsyncClient =
-    new AmazonKinesisAsyncClient().withRegion(region)
+  private[timeout] lazy val kinesis: AmazonKinesisAsync =
+    AmazonKinesisAsyncClientBuilder.standard.withRegion(region).build
 
   /**
     * This creates a source that reads records from AWS Kinesis.

--- a/src/main/scala/com/timeout/KinesisSource.scala
+++ b/src/main/scala/com/timeout/KinesisSource.scala
@@ -1,30 +1,67 @@
 package com.timeout
 
 import java.nio.ByteBuffer
-import java.time.ZonedDateTime
+import java.time.{Clock, ZonedDateTime}
 import java.util.Date
 import java.util.concurrent.{Future => JavaFuture}
 
+import akka.NotUsed
 import akka.stream.scaladsl.Source
 import akka.stream.stage.{GraphStage, OutHandler, StageLogging, TimerGraphStageLogic}
 import akka.stream.{Attributes, Outlet, SourceShape}
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
-import com.amazonaws.services.kinesis.model.{GetRecordsRequest, GetRecordsResult, GetShardIteratorRequest}
+import com.amazonaws.services.kinesis.model._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 object KinesisSource {
 
-  def apply(stream: String, since: ZonedDateTime)(implicit ec: ExecutionContext) =
+  private [timeout] val region: Region =
+    Option(Regions.getCurrentRegion)
+      .getOrElse(Region.getRegion(Regions.EU_WEST_1))
+
+  private[timeout] lazy val kinesis: AmazonKinesisAsyncClient =
+    new AmazonKinesisAsyncClient().withRegion(region)
+
+  /**
+    * This creates a source that reads records from AWS Kinesis.
+    * It is serialisation format agnostic so emits a stream of ByteBuffers
+    */
+  def apply(
+    stream: String,
+    since: ZonedDateTime
+  )(
+    implicit
+    ec: ExecutionContext,
+    clock: Clock = Clock.systemUTC
+  ): Source[ByteBuffer, NotUsed] =
     Source.fromGraph(new KinesisSource(stream, since))
 
-  private[timeout] lazy val kinesis: AmazonKinesisAsyncClient = new AmazonKinesisAsyncClient()
-    .withRegion(Option(Regions.getCurrentRegion).getOrElse(Region.getRegion(Regions.EU_WEST_1)))
+  /**
+    * Construct shard iterator requests
+    * based on a stream description
+    */
+  private[timeout] def shardIteratorRequests(
+    since: ZonedDateTime,
+    stream: StreamDescription
+  )(
+    implicit
+    clock: Clock
+  ): List[GetShardIteratorRequest] =
+    stream.getShards.asScala.toList.map { shard =>
+    val now = clock.instant
+    val readFrom = if (since.toInstant.isBefore(now)) since.toInstant else now
+    new GetShardIteratorRequest()
+      .withShardIteratorType("AT_TIMESTAMP")
+      .withTimestamp(Date.from(readFrom))
+      .withStreamName(stream.getStreamName)
+      .withShardId(shard.getShardId)
+  }
 }
 
 /**
@@ -32,10 +69,16 @@ object KinesisSource {
   * For the stream we maintain a map of current iterator => Future[GetRecordsResponse]
   * and we poll the map every 100ms to send more requests for every completed future
   */
-private[timeout] class KinesisSource(stream: String, since: ZonedDateTime)(implicit val e: ExecutionContext)
-  extends GraphStage[SourceShape[ByteBuffer]] {
-  import KinesisSource.kinesis
+private[timeout] class KinesisSource(
+  streamName: String,
+  since: ZonedDateTime
+)(
+  implicit
+  val e: ExecutionContext,
+  clock: Clock
+) extends GraphStage[SourceShape[ByteBuffer]] {
 
+  import KinesisSource._
   val outlet = Outlet[ByteBuffer]("Kinesis Records")
   override def shape = SourceShape[ByteBuffer](outlet)
 
@@ -45,15 +88,14 @@ private[timeout] class KinesisSource(stream: String, since: ZonedDateTime)(impli
     val buffer = mutable.Map.empty[String, JavaFuture[GetRecordsResult]]
 
     Future {
-      kinesis.describeStream(stream).getStreamDescription.getShards.asScala.par.map { shard =>
-        val req = new GetShardIteratorRequest()
-          .withShardIteratorType("AT_TIMESTAMP")
-          .withTimestamp(Date.from(since.toInstant))
-          .withShardId(shard.getShardId)
-          .withStreamName(stream)
-        val it = kinesis.getShardIterator(req).getShardIterator
-        it -> kinesis.getRecordsAsync(new GetRecordsRequest().withShardIterator(it))
-      }.toMap.seq
+      val stream = kinesis.describeStream(streamName).getStreamDescription
+      shardIteratorRequests(since, stream).toStream.par
+        .map(kinesis.getShardIterator)
+        .map { i =>
+          val iterator = i.getShardIterator
+          val request = new GetRecordsRequest().withShardIterator(iterator)
+          iterator -> kinesis.getRecordsAsync(request)
+        }.toMap.seq
     }.onComplete(getAsyncCallback[Try[Map[String, JavaFuture[GetRecordsResult]]]] { iterators =>
       val unsafeIterators = iterators.get // trigger an exception if we could not bootstrap
       unsafeIterators.foreach(buffer += _)

--- a/src/test/scala/com/timeout/KinesisSourceTest.scala
+++ b/src/test/scala/com/timeout/KinesisSourceTest.scala
@@ -1,0 +1,34 @@
+package com.timeout
+
+import java.time.{Clock, ZonedDateTime}
+import java.util.Date
+
+import com.amazonaws.services.kinesis.model.{Shard, StreamDescription}
+import org.scalatest.{FreeSpec, Matchers}
+
+class KinesisSourceTest extends FreeSpec with Matchers {
+  val now = ZonedDateTime.parse("2017-01-01T07:00:00Z")
+  implicit val clock = Clock.fixed(now.toInstant, now.getZone)
+
+  val stream: StreamDescription = new StreamDescription()
+    .withStreamName("test name")
+    .withShards(
+      new Shard().withShardId("1234"),
+      new Shard().withShardId("2345")
+    )
+
+  "Kinesis Source" - {
+
+    "Should generate one AT_TIMESTAMP iterator request per shard" in {
+      val requests = KinesisSource.shardIteratorRequests(now, stream)
+      requests.map(_.getShardId).toSet shouldEqual Set("1234", "2345")
+      requests.map(_.getShardIteratorType).toSet shouldEqual Set("AT_TIMESTAMP")
+      requests.map(_.getTimestamp).toSet shouldEqual Set(Date.from(clock.instant))
+    }
+
+    "Should cap the timestamp of shard iterator requests to the minimum of (now, since)" in {
+      val requests = KinesisSource.shardIteratorRequests(now.plusDays(1), stream)
+      requests.map(_.getTimestamp).toSet shouldEqual Set(Date.from(clock.instant))
+    }
+  }
+}


### PR DESCRIPTION
- Split out the construction of shard iterator requests into the companion object for testing
- Prevent requesting records from the future by replacing `since` with the current time
- Add a readme