### PR TITLE
Support reissue of expired shard iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ being used in Time Out's data ingestion pipeline and is under active development
 
 ## Installation
 
+Add the following to your `build.sbt`:
+
 ```scala
 resolvers += Resolver.bintrayRepo("timeoutdigital", "releases")
 libraryDependencies += "com.timeout" %% "akka-streams-kinesis" % "0.1.6"
@@ -15,7 +17,7 @@ libraryDependencies += "com.timeout" %% "akka-streams-kinesis" % "0.1.6"
 
 ## Reading from Kinesis
 
-You can read from Kinesis with `KinesisSource`, which uses the AsyncKinesisClient internally. 
+You can read from Kinesis with `KinesisSource`, which uses the `AmazonKinesisAsync` client internally. 
 
 ```scala
 import com.timeout.KinesisSource
@@ -32,9 +34,11 @@ val stage = KinesisSource("my-stream-name", since = since)
  
 ## Writing to Kinesis
 
-You can write to Kinesis with `KinesisGraphStage`. It maintains an internal buffer of records which it flushes periodically to Kinesis. and emits a stream of  `Either[PutRecordsResultEntry, A]` where the left is any failed results from kinesis and the right is the records pushed successfully.
+You can write to Kinesis with `KinesisGraphStage`. It maintains an internal buffer of records which it flushes periodically to Kinesis. and emits a stream of  `Either[PutRecordsResultEntry, A]` where the left is any failed results from Kinesis and the right is the records pushed successfully.
 
-KinesisGraphStage expects you to implement a typeclass `ToPutRecordsRequest[A]` which tells it how to convert the contents of your stream into a `PutRecordsRequest`.
+`KinesisGraphStage` expects you to implement a typeclass `ToPutRecordsRequest[A]` which tells it how to convert the contents of your stream into a `PutRecordsRequest`.
+
+Here's an example of how to write a Stream of `String`s to Kinesis:
 
 ```scala
 import java.nio.ByteBuffer

--- a/README.md
+++ b/README.md
@@ -1,27 +1,34 @@
 # Akka Streams Kinesis
 
 [![Build Status](https://travis-ci.org/timeoutdigital/akka-streams-kinesis.svg?branch=master)](https://travis-ci.org/timeoutdigital/akka-streams-kinesis)
+[![GitHub release](https://img.shields.io/github/tag/timeoutdigital/akka-streams-kinesis.svg)](https://github.com/timeoutdigital/akka-streams-kinesis/releases)
 
-This library allows you to read from and write to Kinesis with Akka Streams. It is currently under active development.
+This library allows you to read from and write to Kinesis with Akka Streams. It is currently 
+being used in Time Out's data ingestion pipeline and is under active development.
+
+## Installation
+
+```scala
+resolvers += Resolver.bintrayRepo("timeoutdigital", "releases")
+libraryDependencies += "com.timeout" %% "akka-streams-kinesis" % "0.1.6"
+```
 
 ## Reading from Kinesis
 
-You can read from Kinesis with `KinesisSource`. It currently polls kinesis every 100ms with the Java async client.
+You can read from Kinesis with `KinesisSource`, which uses the AsyncKinesisClient internally. 
 
 ```scala
 import com.timeout.KinesisSource
 import java.time.ZonedDateTime
 
-val since = ZonedDateTime.now() // from when to start reading the stream
+val since = ZonedDateTime.now // from when to start reading the stream
 val stage = KinesisSource("my-stream-name", since = since)
 ```
 
 ⚠️ Currently not supported:
 
  - Shard iterator types other than `AT_TIMESTAMP`
- - More than 5 minutes of backpressure 
  - [Resharding of the stream](http://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-resharding.html)
-
  
 ## Writing to Kinesis
 

--- a/src/main/scala/com/timeout/KinesisSource.scala
+++ b/src/main/scala/com/timeout/KinesisSource.scala
@@ -6,7 +6,7 @@ import java.util.Date
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import akka.stream.stage.{GraphStage, OutHandler, StageLogging, TimerGraphStageLogic}
+import akka.stream.stage._
 import akka.stream.{Attributes, Outlet, SourceShape}
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
@@ -103,7 +103,7 @@ private[timeout] class KinesisSource(
   val outlet = Outlet[ByteBuffer]("Kinesis Records")
   override def shape = SourceShape[ByteBuffer](outlet)
 
-  override def createLogic(attrs: Attributes) = new TimerGraphStageLogic(shape) with StageLogging {
+  override def createLogic(attrs: Attributes) = new GraphStageLogic(shape) with StageLogging {
 
     /**
       * Adapt Amazon's 2 argument AsyncHandler based functions to execute a block on completion,

--- a/src/main/scala/com/timeout/KinesisSource.scala
+++ b/src/main/scala/com/timeout/KinesisSource.scala
@@ -188,7 +188,7 @@ private[timeout] class KinesisSource(
       case Failure(_: ExpiredIteratorException) =>
         reissueThenGetRecords(iterator)
       case Failure(error) =>
-        log.debug(error.getMessage)
+        log.error(error.getMessage)
         getRecords(iterator)
     }
   }


### PR DESCRIPTION
Also this moves to using the Kinesis Async client for GetRecords,
removing the need to poll the Java futures.