### PR TITLE
KinesisSource: Support TRIM_HORIZON and LATEST shard iterator types

### DIFF
--- a/src/main/scala/com/timeout/KinesisSource.scala
+++ b/src/main/scala/com/timeout/KinesisSource.scala
@@ -70,7 +70,6 @@ object KinesisSource {
     iterator: IteratorType
   )(
     implicit
-    ec: ExecutionContext,
     clock: Clock = Clock.systemUTC
   ): Source[ByteBuffer, NotUsed] =
     Source.fromGraph(new KinesisSource(kinesis, stream, iterator))
@@ -113,7 +112,6 @@ private[timeout] class KinesisSource(
   iterator: IteratorType
 )(
   implicit
-  e: ExecutionContext,
   clock: Clock
 ) extends GraphStage[SourceShape[ByteBuffer]] {
 

--- a/src/main/scala/com/timeout/KinesisSource.scala
+++ b/src/main/scala/com/timeout/KinesisSource.scala
@@ -10,9 +10,9 @@ import akka.stream.stage._
 import akka.stream.{Attributes, Outlet, SourceShape}
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.kinesis.model._
-import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClientBuilder}
+import com.amazonaws.services.kinesis.AmazonKinesisAsync
+import com.timeout.KinesisSource.IteratorType
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -20,14 +20,23 @@ import scala.util.{Failure, Success, Try}
 
 object KinesisSource {
 
-  private [timeout] val region: Regions =
-    Option(Regions.getCurrentRegion)
-      .map(r => Regions.fromName(r.getName))
-      .getOrElse(Regions.EU_WEST_1)
+  /**
+    * Models the ShardIteratorType parameter passed to GetShardIterator
+    * http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html
+    * We don't support sequence number based iterators yet as the source does not emit sequence numbers
+    */
+  sealed trait IteratorType
 
-  private[timeout] lazy val kinesis: AmazonKinesisAsync =
-    AmazonKinesisAsyncClientBuilder.standard.withRegion(region).build
+  object IteratorType {
+    case class AtTimestamp(time: ZonedDateTime) extends IteratorType
+    case object TrimHorizon extends IteratorType
+    case object Latest extends IteratorType
+  }
 
+  /**
+    * A wrapper for a Kinesis shard iterator, that knows how to reissue itself
+    * should it expire due to the 5 minute iterator validity cutoff
+    */
   private [timeout] case class ShardIterator(
     iterator: String,
     reissue: GetShardIteratorRequest
@@ -56,43 +65,52 @@ object KinesisSource {
     * It is serialisation format agnostic so emits a stream of ByteBuffers
     */
   def apply(
+    kinesis: AmazonKinesisAsync,
     stream: String,
-    since: ZonedDateTime
+    iterator: IteratorType
   )(
     implicit
     ec: ExecutionContext,
     clock: Clock = Clock.systemUTC
   ): Source[ByteBuffer, NotUsed] =
-    Source.fromGraph(new KinesisSource(stream, since))
+    Source.fromGraph(new KinesisSource(kinesis, stream, iterator))
 
   /**
     * Construct shard iterator requests
     * based on a stream description
     */
   private[timeout] def shardIteratorRequests(
-    since: ZonedDateTime,
+    iteratorType: IteratorType,
     stream: StreamDescription
   )(
     implicit
     clock: Clock
   ): List[GetShardIteratorRequest] =
     stream.getShards.asScala.toList.map { shard =>
-    val now = clock.instant
-    val readFrom = if (since.toInstant.isBefore(now)) since.toInstant else now
-    new GetShardIteratorRequest()
-      .withShardIteratorType("AT_TIMESTAMP")
-      .withTimestamp(Date.from(readFrom))
-      .withStreamName(stream.getStreamName)
-      .withShardId(shard.getShardId)
-  }
+      val request = new GetShardIteratorRequest()
+        .withStreamName(stream.getStreamName)
+        .withShardId(shard.getShardId)
+
+      iteratorType match {
+        case IteratorType.AtTimestamp(since) =>
+          val now = ZonedDateTime.now(clock)
+          val readFrom = if (since.isBefore(now)) since else now
+          request.withShardIteratorType("AT_TIMESTAMP").withTimestamp(Date.from(readFrom.toInstant))
+        case IteratorType.TrimHorizon =>
+          request.withShardIteratorType("TRIM_HORIZON")
+        case IteratorType.Latest =>
+          request.withShardIteratorType("LATEST")
+      }
+    }
 }
 
 /**
   * A source for kinesis records
   */
 private[timeout] class KinesisSource(
+  kinesis: AmazonKinesisAsync,
   streamName: String,
-  since: ZonedDateTime
+  iterator: IteratorType
 )(
   implicit
   e: ExecutionContext,
@@ -140,7 +158,7 @@ private[timeout] class KinesisSource(
       * Any errors here are essentially unrecoverable so we explode, hence the .gets
       */
     run(streamName)(kinesis.describeStreamAsync) { stream =>
-      shardIteratorRequests(since, stream.get.getStreamDescription).foreach { request =>
+      shardIteratorRequests(iterator, stream.get.getStreamDescription).foreach { request =>
         run(request)(kinesis.getShardIteratorAsync) { iteratorResult =>
           getRecords(ShardIterator(iteratorResult.get.getShardIterator, request))
         }

--- a/src/test/scala/com/timeout/KinesisSourceTest.scala
+++ b/src/test/scala/com/timeout/KinesisSourceTest.scala
@@ -4,6 +4,7 @@ import java.time.{Clock, ZonedDateTime}
 import java.util.Date
 
 import com.amazonaws.services.kinesis.model.{Shard, StreamDescription}
+import com.timeout.KinesisSource.IteratorType
 import org.scalatest.{FreeSpec, Matchers}
 
 class KinesisSourceTest extends FreeSpec with Matchers {
@@ -20,15 +21,29 @@ class KinesisSourceTest extends FreeSpec with Matchers {
   "Kinesis Source" - {
 
     "Should generate one AT_TIMESTAMP iterator request per shard" in {
-      val requests = KinesisSource.shardIteratorRequests(now, stream)
+      val requests = KinesisSource.shardIteratorRequests(IteratorType.AtTimestamp(now), stream)
       requests.map(_.getShardId).toSet shouldEqual Set("1234", "2345")
       requests.map(_.getShardIteratorType).toSet shouldEqual Set("AT_TIMESTAMP")
       requests.map(_.getTimestamp).toSet shouldEqual Set(Date.from(clock.instant))
     }
 
     "Should cap the timestamp of shard iterator requests to the minimum of (now, since)" in {
-      val requests = KinesisSource.shardIteratorRequests(now.plusDays(1), stream)
+      val requests = KinesisSource.shardIteratorRequests(IteratorType.AtTimestamp(now.plusDays(1)), stream)
       requests.map(_.getTimestamp).toSet shouldEqual Set(Date.from(clock.instant))
+    }
+
+    "Should map IteratorType.Latest to LATEST" in {
+      val latest = KinesisSource.shardIteratorRequests(IteratorType.Latest, stream)
+      latest.head.getShardIteratorType shouldEqual "LATEST"
+      latest.head.getStartingSequenceNumber shouldEqual null
+      latest.head.getTimestamp shouldEqual null
+    }
+
+    "Should map IteratorType.TrimHorizon to TRIM_HORIZON" in {
+      val latest = KinesisSource.shardIteratorRequests(IteratorType.TrimHorizon, stream)
+      latest.head.getShardIteratorType shouldEqual "TRIM_HORIZON"
+      latest.head.getStartingSequenceNumber shouldEqual null
+      latest.head.getTimestamp shouldEqual null
     }
   }
 }


### PR DESCRIPTION
Adds the ability to start reading from the beginning and end of a Kinesis stream.

The motivation for this is that [Kinesalite](https://github.com/mhart/kinesalite) doesn't support `AT_TIMESTAMP`

This is a BC break since we're < 1.0, so I also took the opportunity to align KinesisSource with KinesisFlow in accepting an external `AmazonKinesisAsync` as we'll also need to do that to run tests with Kinesalite, and defaulting to EU_WEST_1 is probably not too helpful if you're not in Europe.
