### PR TITLE
Fix expired shard iterators not being reissued

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 scala:
   - 2.11.8
-  - 2.12.2
+  - 2.12.3
 
 jdk:
   - oraclejdk8
@@ -17,4 +17,5 @@ before_script:
   - npm install -g kinesalite
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - if [ -n "$TRAVIS_PULL_REQUEST" ]; then TEST='testOnly * -- -l org.scalatest.tags.Slow'; else TEST="test"; fi
+  - sbt ++$TRAVIS_SCALA_VERSION $TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ before_script:
   - npm install -g kinesalite
 
 script:
-  - if [ -n "$TRAVIS_PULL_REQUEST" ]; then TEST='testOnly * -- -l org.scalatest.tags.Slow'; else TEST="test"; fi
-  - sbt ++$TRAVIS_SCALA_VERSION $TEST
+  - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 
 scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.11.11", "2.12.2")
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 releaseCrossBuild := true
 


### PR DESCRIPTION
This unfortunate regression was caused by the ShardIteratorExpiredExceptions being client errors, and so they were rethrown rather than caught