### PR TITLE
Limit maximum request size

### DIFF
--- a/src/test/scala/com/timeout/KinesisGraphStageTest.scala
+++ b/src/test/scala/com/timeout/KinesisGraphStageTest.scala
@@ -31,7 +31,7 @@ class KinesisGraphStageTest extends AkkaStreamsTest with Matchers with PatienceC
     result((1 to r.getRecords.size).map(_ => resultEntry.withErrorMessage("Failure").withErrorCode("F")))
 
   def kinesis(client: KinesisGraphStage.PutRecords) =
-    new KinesisGraphStage[PutRecordsRequestEntry](client, "test")
+    new KinesisGraphStage[PutRecordsRequestEntry](client, "test", 250 )
 
 
   "Kinesis graph stage" - {


### PR DESCRIPTION
We've run into issue when the single request consisting of several records exceeded AWS imposed request size limit, which is 5MB. To overcome that issue we can be dividing buffered records into several requests instead of sending just single one.

My approach won't help if a single record exceeds AWS limits.

I am making as well the buffer size configurable for the client.