### PR TITLE
Make sending threshold and max buffer size configurable

### DIFF
--- a/src/test/scala/com/timeout/KinesisGraphStageTest.scala
+++ b/src/test/scala/com/timeout/KinesisGraphStageTest.scala
@@ -31,7 +31,7 @@ class KinesisGraphStageTest extends AkkaStreamsTest with Matchers with PatienceC
     result((1 to r.getRecords.size).map(_ => resultEntry.withErrorMessage("Failure").withErrorCode("F")))
 
   def kinesis(client: KinesisGraphStage.PutRecords) =
-    new KinesisGraphStage[PutRecordsRequestEntry](client, "test")
+    new KinesisGraphStage[PutRecordsRequestEntry](client, "test", 250, 500)
 
 
   "Kinesis graph stage" - {


### PR DESCRIPTION
500 isn't working for larger messages. In the next iteration I will try to improve how we are handling AWS byte size limits for request and record.